### PR TITLE
Moved Docker image build to install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ install:
   # Check Molecule version
   - molecule --version
 
+  # Build the Docker images
+  - molecule create
+  - molecule destroy
+
 script:
   - molecule test
 


### PR DESCRIPTION
This allows us to collapse the logs for the image build.