### PR TITLE
Disable Ansible Galaxy notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,3 @@ script:
 branches:
   only:
     - master
-
-notifications:
-  webhooks: https://galaxy.ansible.com/api/v1/notifications/


### PR DESCRIPTION
Since a recent Galaxy update the notification auto publishes the role; since this role is specific to the GantSign development environment it shouldn't be published to Ansible Galaxy.