### PR TITLE
Dropped support for Ubuntu Wily

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - trusty
-        - wily
         - xenial
   galaxy_tags:
     - terminal


### PR DESCRIPTION
It's no longer a supported Ubuntu version.