### PR TITLE
Dropped support for Ubuntu Trusty

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Requirements
 
     * Ubuntu
 
-        * Trusty (14.04)
         * Xenial (16.04)
 
 Example Playbook

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
   galaxy_tags:
     - terminal


### PR DESCRIPTION
The tests are failing and Xenial has been out for ages now.