### PR TITLE
Resolved apt module syntax deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,19 +2,18 @@
 - name: install common command line tools
   become: yes
   apt:
-    name: '{{ item }}'
+    name:
+      - curl
+      - dos2unix
+      - glances
+      - grc
+      - htop
+      - httpie
+      - jq
+      - mtr
+      - multitail
+      - shellcheck
+      - silversearcher-ag
+      - tree
+      - wget
     state: present
-  with_items:
-    - curl
-    - dos2unix
-    - glances
-    - grc
-    - htop
-    - httpie
-    - jq
-    - mtr
-    - multitail
-    - shellcheck
-    - silversearcher-ag
-    - tree
-    - wget


### PR DESCRIPTION
```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: {{ item }}`, please use `name: [u'curl', u'dos2unix',
u'glances', u'grc', u'htop', u'httpie', u'jq', u'mtr', u'multitail',
u'shellcheck', u'silversearcher-ag', u'tree', u'wget']` and remove the loop.
This feature will be removed in version 2.11. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg.
```