### PR TITLE
Increased minimum Ansible version to 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - MOLECULEW_USE_SYSTEM=true
   matrix:
     # Spin off separate builds for each of the following versions of Ansible
-    - MOLECULEW_ANSIBLE=2.6.18
+    - MOLECULEW_ANSIBLE=2.7.15
     - MOLECULEW_ANSIBLE=2.9.1
 
 # Require the standard build environment

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Role to install my favourite command line tools.
 Requirements
 ------------
 
-* Ansible >= 2.6
+* Ansible >= 2.7
 
 * Linux Distribution
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role for installing my favourite command line tools.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.6
+  min_ansible_version: 2.7
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
Ansible no longer supports versions earlier than 2.7.