### PR TITLE
Configured Travis CI to test on Ubuntu Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ env:
 # Require the standard build environment
 sudo: required
 
-# Require Ubuntu 14.04
-dist: trusty
+# Require Ubuntu 16.04
+dist: xenial
 
 # Require Docker
 services:


### PR DESCRIPTION
As of the 13th of August 2019 Ubuntu Xenial is the default Linux distribution for Travis CI.