### PR TITLE
Migrated to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ansible Role: Command Line Tools
 ================================
 
-[![Build Status](https://travis-ci.org/gantsign/ansible-role-command-line-tools.svg?branch=master)](https://travis-ci.org/gantsign/ansible-role-command-line-tools)
+[![Build Status](https://travis-ci.com/gantsign/ansible-role-command-line-tools.svg?branch=master)](https://travis-ci.com/gantsign/ansible-role-command-line-tools)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/gantsign/ansible-role-command-line-tools/master/LICENSE)
 
 Role to install my favourite command line tools.


### PR DESCRIPTION
`travis-ci.org` will be discontinued in December.