### PR TITLE
Removed unnecessary prolog from pytest file

### DIFF
--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -1,10 +1,4 @@
 import pytest
-import os
-
-import testinfra.utils.ansible_runner
-
-testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
 @pytest.mark.parametrize('command,arg', [


### PR DESCRIPTION
Made redundant by `conftest.py`.